### PR TITLE
setting conditional build step plugin dep to the current vivid snapsh…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>conditional-buildstep</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.6-SNAPSHOT</version>
     </dependency>
       <dependency>
           <groupId>io.fabric8</groupId>

--- a/src/main/java/com/vividseats/k8s/PodStatusCondition.java
+++ b/src/main/java/com/vividseats/k8s/PodStatusCondition.java
@@ -52,7 +52,6 @@ public class PodStatusCondition extends RunCondition {
                     .envs(environment)
                     .stderr(buildListener.getLogger())
                     .stdout(pipedOutputStream)
-                    .pwd(abstractBuild.getWorkspace())
                     .quiet(true)
                     .join();
 
@@ -70,7 +69,7 @@ public class PodStatusCondition extends RunCondition {
             }
 
         } catch (IOException e) {
-            buildListener.getLogger().append(e.getMessage());
+            buildListener.getLogger().append(e.getMessage() + "\n");
         }
         return false;
     }


### PR DESCRIPTION
…ot version. removing .pwd() line from command builder due to jenkins throwing an error. Current job path is not needed anyway